### PR TITLE
Refactor package structure for improved readability

### DIFF
--- a/src/main/kotlin/br/com/pokemon/tradecardgame/PokemonTradeCardGameApplication.kt
+++ b/src/main/kotlin/br/com/pokemon/tradecardgame/PokemonTradeCardGameApplication.kt
@@ -1,4 +1,4 @@
-package br.com.tcg.pokemon.pokemontradecardgame
+package br.com.pokemon.tradecardgame
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/adapter/web/controller/CardController.kt
+++ b/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/adapter/web/controller/CardController.kt
@@ -1,4 +1,4 @@
-package br.com.tcg.pokemon.pokemontradecardgame.infraestruture.adapter.web.controller
+package br.com.pokemon.tradecardgame.infraestruture.adapter.web.controller
 
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/config/security/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package br.com.tcg.pokemon.pokemontradecardgame.infraestruture.config.security
+package br.com.pokemon.tradecardgame.infraestruture.config.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/config/security/SecurityExceptionHandler.kt
+++ b/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/config/security/SecurityExceptionHandler.kt
@@ -1,6 +1,6 @@
-package br.com.tcg.pokemon.pokemontradecardgame.infraestruture.config.security
+package br.com.pokemon.tradecardgame.infraestruture.config.security
 
-import br.com.tcg.pokemon.pokemontradecardgame.infraestruture.dto.ErrorDetails
+import br.com.pokemon.tradecardgame.infraestruture.dto.ErrorDetails
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.access.AccessDeniedException

--- a/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/dto/ErrorDetails.kt
+++ b/src/main/kotlin/br/com/pokemon/tradecardgame/infraestruture/dto/ErrorDetails.kt
@@ -1,4 +1,4 @@
-package br.com.tcg.pokemon.pokemontradecardgame.infraestruture.dto
+package br.com.pokemon.tradecardgame.infraestruture.dto
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException

--- a/src/test/kotlin/br/com/pokemon/tradecardgame/PokemonTradeCardGameApplicationTests.kt
+++ b/src/test/kotlin/br/com/pokemon/tradecardgame/PokemonTradeCardGameApplicationTests.kt
@@ -1,4 +1,4 @@
-package br.com.tcg.pokemon.pokemontradecardgame
+package br.com.pokemon.tradecardgame
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest


### PR DESCRIPTION
Reorganized the package structure to remove redundant "tcg.pokemon" segment. This update simplifies namespaces, enhancing both readability and maintainability. No functional changes are introduced.